### PR TITLE
Add rating label to pending orders events

### DIFF
--- a/src/list_orders.md
+++ b/src/list_orders.md
@@ -20,6 +20,7 @@ Mostro publishes new orders with event kind `38383` and status `pending`:
       ["fa", "100"],
       ["pm", "face to face"],
       ["premium", "1"],
+      ["rating", "[\"rating\",{\"days\":10,\"total_rating\":4.5,\"total_reviews\":7}]"],
       ["network", "mainnet"],
       ["layer", "lightning"],
       ["expiration", "1719391096"],

--- a/src/new_buy_order.md
+++ b/src/new_buy_order.md
@@ -94,6 +94,7 @@ Mostro publishes this order as an event kind `38383` with status `pending`:
       ["fa", "100"],
       ["pm", "face to face"],
       ["premium", "1"],
+      ["rating", "[\"rating\",{\"days\":10,\"total_rating\":4.5,\"total_reviews\":7}]"],
       ["network", "mainnet"],
       ["layer", "lightning"],
       ["expiration", "1719391096"],

--- a/src/new_buy_order_ln_address.md
+++ b/src/new_buy_order_ln_address.md
@@ -92,6 +92,7 @@ Mostro publishes this order as an event kind `38383` with status `pending`:
       ["fa", "100"],
       ["pm", "face to face"],
       ["premium", "1"],
+      ["rating", "[\"rating\",{\"days\":10,\"total_rating\":4.5,\"total_reviews\":7}]"],
       ["network", "mainnet"],
       ["layer", "lightning"],
       ["expiration", "1719391096"],

--- a/src/new_sell_order.md
+++ b/src/new_sell_order.md
@@ -100,6 +100,7 @@ Mostro publishes this order as an event kind `38383` with status `pending`:
       ["fa", "100"],
       ["pm", "face to face", "bank transfer"],
       ["premium", "1"],
+      ["rating", "[\"rating\",{\"days\":10,\"total_rating\":4.5,\"total_reviews\":7}]"],
       ["network", "mainnet"],
       ["layer", "lightning"],
       ["expiration", "1719391096"],

--- a/src/new_sell_range_order.md
+++ b/src/new_sell_range_order.md
@@ -82,6 +82,7 @@ Mostro publishes this order as an event kind `38383` with status `pending`:
       ["fa", "10", "20"],
       ["pm", "face to face"],
       ["premium", "1"],
+      ["rating", "[\"rating\",{\"days\":10,\"total_rating\":4.5,\"total_reviews\":7}]"],
       ["network", "mainnet"],
       ["layer", "lightning"],
       ["expiration", "1719391096"],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new "rating" tag to published buy and sell order events, displaying rating information such as days active, total rating, and total reviews. This provides enhanced visibility into order ratings for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->