### PR TITLE
Add separate event kinds for ratings, info, and disputes

### DIFF
--- a/src/admin_cancel_order.md
+++ b/src/admin_cancel_order.md
@@ -74,7 +74,7 @@ The second event updates the addressable dispute event with status `seller-refun
     "id": "098e8622eae022a79bc793984fccbc5ea3f6641bdcdffaa031c00d3bd33ca5a0",
     "pubkey": "<Mostro's pubkey>",
     "created_at": 1703274022,
-    "kind": 38383,
+    "kind": 38386,
     "tags": [
       ["d", "efc75871-2568-40b9-a6ee-c382d4d6de01"],
       ["s", "seller-refunded"],

--- a/src/admin_settle_order.md
+++ b/src/admin_settle_order.md
@@ -46,7 +46,7 @@ Mostro updates the addressable dispute event with status `settled`:
     "id": "098e8622eae022a79bc793984fccbc5ea3f6641bdcdffaa031c00d3bd33ca5a0",
     "pubkey": "<Mostro's pubkey>",
     "created_at": 1703274022,
-    "kind": 38383,
+    "kind": 38386,
     "tags": [
       ["d", "efc75871-2568-40b9-a6ee-c382d4d6de01"],
       ["s", "settled"],

--- a/src/dispute.md
+++ b/src/dispute.md
@@ -68,7 +68,7 @@ Here is an example of the event sent by Mostro:
     "id": "<Event id>",
     "pubkey": "<Mostro's pubkey>",
     "created_at": 1703016565,
-    "kind": 38383,
+    "kind": 38386,
     "tags": [
       ["d", "<Dispute Id>"],
       ["s", "initiated"],
@@ -159,7 +159,7 @@ Also Mostro will broadcast a new addressable dispute event to update the dispute
     "id": "<Event id>",
     "pubkey": "<Mostro's pubkey>",
     "created_at": 1703020540,
-    "kind": 38383,
+    "kind": 38386,
     "tags": [
       ["d", "<Dispute Id>"],
       ["s", "in-progress"],

--- a/src/list_disputes.md
+++ b/src/list_disputes.md
@@ -1,6 +1,6 @@
 # Listing Disputes
 
-Mostro publishes new disputes with event kind `38383` and status `initiated`:
+Mostro publishes new disputes with event kind `38386` and status `initiated`:
 
 ```json
 [
@@ -10,7 +10,7 @@ Mostro publishes new disputes with event kind `38383` and status `initiated`:
     "id": "<Event id>",
     "pubkey": "<Mostro's pubkey>",
     "created_at": 1703016565,
-    "kind": 38383,
+    "kind": 38386,
     "tags": [
       ["d", "<Dispute Id>"],
       ["s", "initiated"],
@@ -23,4 +23,4 @@ Mostro publishes new disputes with event kind `38383` and status `initiated`:
 ]
 ```
 
-Clients can query this events by nostr event kind `38383`, nostr event author, dispute status (`s`), type (`z`)
+Clients can query these events by nostr event kind `38386`, nostr event author, dispute status (`s`), type (`z`)

--- a/src/order_event.md
+++ b/src/order_event.md
@@ -1,5 +1,18 @@
 # Peer-to-peer Order events. NIP-69
 
+## Mostro Event Kinds
+
+Mostro uses different event kinds for different types of data:
+
+| Event Type | Kind  | Document (`z` tag) |
+|------------|-------|--------------------|
+| Orders     | 38383 | `order`            |
+| Ratings    | 38384 | `rating`           |
+| Info       | 38385 | `info`             |
+| Disputes   | 38386 | `dispute`          |
+
+This document focuses on the **Order** event (kind `38383`), which is used for the P2P order book.
+
 ## Abstract
 
 Peer-to-peer (P2P) platforms have seen an upturn in recent years, while having more and more options is positive, in the specific case of p2p, having several options contributes to the liquidity split, meaning sometimes there's not enough assets available for trading. If we combine all these individual solutions into one big pool of orders, it will make them much more competitive compared to centralized systems, where a single authority controls the liquidity.

--- a/src/other_events.md
+++ b/src/other_events.md
@@ -13,7 +13,7 @@ This event contains specific data about a Mostro instance. The instance is ident
   {
     "id": "<Event id>",
     "pubkey": "<Mostro's pubkey>",
-    "kind": 38383
+    "kind": 38385,
     "tags": [
       [
         "d",

--- a/src/overview.md
+++ b/src/overview.md
@@ -1,6 +1,15 @@
 ## Overview
 
-In order to have a shared order's book, Mostro daemon send [Addressable Events](https://github.com/nostr-protocol/nips/blob/master/01.md#kinds) with `38383` as event `kind`, you can find more details about that specific event [here](./order_event.md)
+Mostro uses [Addressable Events](https://github.com/nostr-protocol/nips/blob/master/01.md#kinds) to publish different types of information. Each event type has its own `kind`:
+
+| Event Type | Kind  | Description |
+|------------|-------|-------------|
+| Orders     | 38383 | P2P order events for the shared order book |
+| Ratings    | 38384 | User rating events |
+| Info       | 38385 | Mostro instance status and information |
+| Disputes   | 38386 | Dispute events |
+
+You can find more details about the order event [here](./order_event.md)
 
 ## The Message
 

--- a/src/user_rating.md
+++ b/src/user_rating.md
@@ -64,7 +64,7 @@ Mostro updates the addressable rating event, in this event the `d` tag will be t
     "id": "<Event id>",
     "pubkey": "<Mostro's pubkey>",
     "created_at": 1702637077,
-    "kind": 38383,
+    "kind": 38384,
     "tags": [
       ["d", "<Seller's trade pubkey>"],
       ["total_reviews", "1"],
@@ -72,6 +72,7 @@ Mostro updates the addressable rating event, in this event the `d` tag will be t
       ["last_rating", "1"],
       ["max_rate", "2"],
       ["min_rate", "5"],
+      ["y", "mostro"],
       ["z", "rating"]
     ],
     "content": "",


### PR DESCRIPTION
- Orders: kind 38383 (unchanged)
- Ratings: kind 38384
- Info: kind 38385
- Disputes: kind 38386

Updated all documentation to reflect the new event kinds and added reference tables in overview.md and order_event.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new "Mostro Event Kinds" reference section mapping event types to their identifiers.
  * Updated event kind identifiers across dispute, order, and rating documentation for consistency.
  * Enhanced overview with clarified event type table and improved contextual descriptions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->