### PR TITLE
Documents initiator field in restore data

### DIFF
--- a/src/restore_session.md
+++ b/src/restore_session.md
@@ -53,7 +53,8 @@ Mostro will respond with a message containing all non-finalized orders (e.g., st
               "dispute_id": "<Dispute Id>",
               "order_id": "<Order Id>",
               "trade_index": 4,
-              "status": "initiated"
+              "status": "initiated",
+              "initiator": "seller"
             }
           ]
         }
@@ -68,7 +69,7 @@ Mostro will respond with a message containing all non-finalized orders (e.g., st
 
 * `restore_data`: Wrapper object that contains the session recovery data.
 * `restore_data.orders`: An array of active or ongoing orders with their `id`, `trade_index`, and current `status`.
-* `restore_data.disputes`: An array of ongoing disputes with `dispute_id`, the associated `order_id`, and `trade_index` and current `status` of the dispute.
+* `restore_data.disputes`: An array of ongoing disputes with `dispute_id`, the associated `order_id`, `trade_index`, current `status`, and `initiator` (`"buyer"`, `"seller"`, or `null` if unknown).
 
 ## Example Use Case
 
@@ -95,7 +96,7 @@ When switching to desktop, after restoring the mnemonic, the client sends `resto
             { "id": "xyz-999", "trade_index": 4, "status": "dispute" }
           ],
           "disputes": [
-            { "dispute_id": "dis-001", "order_id": "xyz-999", "trade_index": 4, "status": "initiated" }
+            { "dispute_id": "dis-001", "order_id": "xyz-999", "trade_index": 4, "status": "initiated", "initiator": "seller" }
           ]
         }
       }

--- a/src/restore_session.md
+++ b/src/restore_session.md
@@ -68,7 +68,7 @@ Mostro will respond with a message containing all non-finalized orders (e.g., st
 ### Fields
 
 * `restore_data`: Wrapper object that contains the session recovery data.
-* `restore_data.orders`: An array of active or ongoing orders with their `id`, `trade_index`, and current `status`.
+* `restore_data.orders`: An array of active or ongoing orders with their `order_id`, `trade_index`, and current `status`.
 * `restore_data.disputes`: An array of ongoing disputes with `dispute_id`, the associated `order_id`, `trade_index`, current `status`, and `initiator` (`"buyer"`, `"seller"`, or `null` if unknown).
 
 ## Example Use Case


### PR DESCRIPTION
Closes #28 
Depends on: https://github.com/MostroP2P/mostro/issues/598
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The restore_session API response now includes an initiator field on dispute objects indicating who opened the dispute ("buyer", "seller", or null).

* **Documentation**
  * API docs and example payloads updated to show the new initiator field for disputes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->