### PR TITLE
docs: send bond-slashed notice to slashed party on dispute resolution

### DIFF
--- a/src/admin_cancel_order.md
+++ b/src/admin_cancel_order.md
@@ -51,6 +51,8 @@ Accepted combinations on `admin-cancel`:
 
 Whenever a side is slashed and the operator has configured `slash_node_share_pct < 1.0`, the non-slashed counterparty is subsequently asked to provide a Lightning invoice for their share of the bond via [Bond payout invoice](./add_bond_invoice.md).
 
+Each slashed party is also sent a [`bond-slashed`](./bond_slashed.md) forfeiture notice for the slashed bond amount, in addition to the `admin-canceled` confirmation below.
+
 ## Mostro response
 
 Mostro will send this message to the both parties buyer/seller and to the admin:

--- a/src/admin_settle_order.md
+++ b/src/admin_settle_order.md
@@ -51,6 +51,8 @@ Accepted combinations on `admin-settle`:
 
 Whenever a side is slashed and the operator has configured `slash_node_share_pct < 1.0`, the non-slashed counterparty is subsequently asked to provide a Lightning invoice for their share of the bond via [Bond payout invoice](./add_bond_invoice.md).
 
+Each slashed party is also sent a [`bond-slashed`](./bond_slashed.md) forfeiture notice for the slashed bond amount, in addition to the `admin-settled` confirmation below.
+
 ## Mostro response
 
 Mostro will send this message to the both parties buyer/seller and to the admin:

--- a/src/bond_slashed.md
+++ b/src/bond_slashed.md
@@ -2,7 +2,7 @@
 
 The `bond-slashed` action is a notification Mostro sends to a bonded party when their anti-abuse bond has been **settled due to a waiting-state timeout**. It is a forfeiture notice: the bond HTLC has already been claimed into Mostro's wallet by the time this message is sent.
 
-> **Scope.** This action is only emitted on the **timeout slash** path (scheduler-driven, gated by `bond_slash_on_waiting_timeout = "true"` in the Mostro info event — see [Other events published by Mostro](./other_events.md#anti-abuse-bond-policy-tags)). It is **not** sent on the dispute-slash path — when a solver slashes a bond via [`admin-settle`](./admin_settle_order.md) or [`admin-cancel`](./admin_cancel_order.md), the slashed party receives the `admin-settled` / `admin-canceled` confirmation instead.
+> **Scope.** This action is emitted on the **timeout slash** path (scheduler-driven, gated by `bond_slash_on_waiting_timeout = "true"` in the Mostro info event — see [Other events published by Mostro](./other_events.md#anti-abuse-bond-policy-tags)). It is **also** sent on the dispute-slash path — when a solver slashes a bond via [`admin-settle`](./admin_settle_order.md) or [`admin-cancel`](./admin_cancel_order.md), the slashed party receives a `bond-slashed` notice **in addition to** the `admin-settled` / `admin-canceled` confirmation.
 
 ## Direction and trigger
 
@@ -58,4 +58,4 @@ After `bond-slashed` is sent to the responsible party, Mostro also:
 
 ## Note on cancels vs. slashes
 
-A cancel sent by either party **before** the timeout elapses never triggers `bond-slashed`. Bonds are always released (never slashed) on user-initiated cancels. Only the automated scheduler-driven timeout slash path emits this action, and only when `slash_on_waiting_timeout = true` is set by the operator.
+A cancel sent by either party **before** the timeout elapses never triggers `bond-slashed`. Bonds are always released (never slashed) on user-initiated cancels. This action is emitted by the automated scheduler-driven timeout slash path (when `slash_on_waiting_timeout = true` is set by the operator) and by a solver's slash directive on a dispute.

--- a/src/message_suggestions_for_actions.md
+++ b/src/message_suggestions_for_actions.md
@@ -26,7 +26,7 @@ Below are suggestions for messages that clients can show to users when receiving
   Your bond payout of `amount` Sats has been sent successfully. The funds should arrive in your Lightning wallet shortly.
 
 - **bond-slashed:**  
-  Your anti-abuse bond of `amount` Sats has been forfeited. This happened because the waiting-state timeout elapsed before you completed your required action on order `id`. The bond has been settled into the node's wallet.
+  You have lost your anti-abuse bond of `amount` Sats for your order `id`.
 
 - **add-invoice:**  
   Please send me an invoice for `amount` satoshis equivalent to `fiat_code` `fiat_amount`. This is where I will send the funds upon trade completion. If you don’t provide the invoice within `expiration_seconds`, the trade will be canceled.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that slashed parties receive `bond-slashed` notifications when bonds are forfeited during both automated timeout scenarios and when a solver slashes via admin settlement or cancellation.
  * Updated settlement and cancellation dispute documentation to specify additional notification types.
  * Simplified message text for bond-slashed notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->