### PR TITLE
docs(chat): add mostro-chat as reference implementation

### DIFF
--- a/src/chat.md
+++ b/src/chat.md
@@ -477,4 +477,6 @@ pub(K_sign), the author: 1dba04571059183f76b148119cfa6f8004dad30cb4e810180a6df17
 
 Both parties derive that pair from their own side of the ECDH, and these values are what the example above prints. NIP-44 v2 uses a random nonce, so ciphertexts are not reproducible: check the **derived pubkeys** against this vector first, then verify a round trip through `mostro_wrap` / `mostro_unwrap`.
 
-More details about this implementation can be found in this [repository](https://github.com/MostroP2P/mostro-chat).
+## Reference implementation
+
+[mostro-chat](https://github.com/MostroP2P/mostro-chat) is a terminal (TUI) chat client that implements this specification end to end and serves as the reference implementation: shared-key derivation with domain separation, the kind 14 outer / kind 1 inner event structure, NIP-44 self-encryption under `K_conv`, and the full validation order described in [Client security requirements](#client-security-requirements). Its code is kept up to date with this document — when in doubt about how the P2P chat should behave, consult that repository alongside the [test vector](#test-vector).


### PR DESCRIPTION
## Summary

Replaces the brief closing mention of the mostro-chat repository in `src/chat.md` with a dedicated **Reference implementation** section. It presents [mostro-chat](https://github.com/MostroP2P/mostro-chat) as a TUI chat client that implements the P2P chat spec end to end — shared-key derivation with domain separation, the kind 14 outer / kind 1 inner event structure, NIP-44 self-encryption under `K_conv`, and the full validation order — and points implementers to it (alongside the test vector) as the up-to-date example of how the chat must behave.

## Test plan

- [x] `mdbook`-compatible Markdown, internal anchors (`#client-security-requirements`, `#test-vector`) match existing headings
- [x] No changes to normative spec content or code examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HnmVyPHQWiuJTJjotuctctFK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a reference implementation section to the chat specification.
  * Documented the implementation’s supported encryption, message structure, key derivation, and validation behavior.
  * Added guidance to consult the reference implementation and test vector when behavior is unclear.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->